### PR TITLE
fix on conflict in postgresql dialect

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -47,4 +47,4 @@ func (d sqlite3Dialect) PlaceholderFormat() PlaceholderFormat    { return Questi
 // OnConflictFormat is the standard on conflict format for each dialect
 func (d mySQLDialect) OnConflictFormat() OnConflictFormat      { return OnDuplicate }
 func (d postgreSQLDialect) OnConflictFormat() OnConflictFormat { return OnConflict }
-func (d sqlite3Dialect) OnConflictFormat() OnConflictFormat    { return OnConflictWithKey }
+func (d sqlite3Dialect) OnConflictFormat() OnConflictFormat    { return OnConflict }

--- a/insert.go
+++ b/insert.go
@@ -334,24 +334,15 @@ type OnConflictFormat interface {
 
 // Global variables for different OnConflictFormats
 var (
-	OnConflict = onConflictFormat{}
-
-	OnConflictWithKey = onConflictWithKeyFormat{}
-
+	OnConflict  = onConflictFormat{}
 	OnDuplicate = onDuplicateFormat{}
 )
 
 type onConflictFormat struct{}
-type onConflictWithKeyFormat struct{}
 type onDuplicateFormat struct{}
 
-// String generates the string: ON CONFLICT DO UPDATE SET
-func (onConflictFormat) String(cols []string) string {
-	return " ON CONFLICT DO UPDATE SET "
-}
-
 // String generates the string: ON CONFLICT(col1,col2) DO UPDATE SET
-func (onConflictWithKeyFormat) String(cols []string) string {
+func (onConflictFormat) String(cols []string) string {
 	key := ""
 	if len(cols) > 0 {
 		key = fmt.Sprintf(" (%s)", strings.Join(cols, ","))

--- a/insert_test.go
+++ b/insert_test.go
@@ -115,13 +115,13 @@ func TestInsertOnConflictBuilderToSql(t *testing.T) {
 func TestInsertBuilderOnConflictFormat(t *testing.T) {
 	b := Insert("test").Values(1, 2).OnConflictSet("a", 1)
 
-	sql, _, _ := b.OnConflictFormat(OnConflict).ToSql()
-	assert.Equal(t, "INSERT INTO test VALUES (?,?) ON CONFLICT DO UPDATE SET a = ?", sql)
-
-	sql, _, _ = b.OnConflictFormat(OnDuplicate).ToSql()
+	sql, _, _ := b.OnConflictFormat(OnDuplicate).ToSql()
 	assert.Equal(t, "INSERT INTO test VALUES (?,?) ON DUPLICATE KEY UPDATE a = ?", sql)
 
-	sql, _, _ = b.OnConflictFormat(OnConflictWithKey).OnConflictKey("id", "method").ToSql()
+	sql, _, _ = b.OnConflictFormat(OnConflict).ToSql()
+	assert.Equal(t, "INSERT INTO test VALUES (?,?) ON CONFLICT DO UPDATE SET a = ?", sql)
+
+	sql, _, _ = b.OnConflictFormat(OnConflict).OnConflictKey("id", "method").ToSql()
 	assert.Equal(t, "INSERT INTO test VALUES (?,?) ON CONFLICT (id,method) DO UPDATE SET a = ?", sql)
 
 	b = Insert("test").Values(1, 2).OnConflictFormat(OnDuplicate)


### PR DESCRIPTION
Postgres needs an index or column list after `on conflict` as in:
ON CONFLICT (xxx) DO SET a=1,b=2,...

i.e., it uses 'OnConflictWithKey'.